### PR TITLE
adds specific express handlebars version

### DIFF
--- a/docs/Bootcamp/Unit-5-Human_Computer_Interaction/0.5.2-Server_Side_Rendering.html
+++ b/docs/Bootcamp/Unit-5-Human_Computer_Interaction/0.5.2-Server_Side_Rendering.html
@@ -103,7 +103,10 @@
 <span class="hljs-tag">&lt;/<span class="hljs-name">section</span>&gt;</span>
 </code></pre>
 <h4>Dependencies</h4>
-<pre><code class="language-sh">npm install handlebars express-handlebars @handlebars/allow-prototype-access
+<pre><code class="language-sh">npm install handlebars  @handlebars/allow-prototype-access
+</code></pre>
+<br />
+<pre><code class="language-sh">npm install express-handlebars@5.3.2
 </code></pre>
 <h4>Example Configure</h4>
 <pre><code class="language-javascript"><span class="hljs-keyword">const</span> express = <span class="hljs-built_in">require</span>(<span class="hljs-string">&#x27;express&#x27;</span>);


### PR DESCRIPTION
Specifies version of express-handlebars (5.3.2) to avoid breaking changes in v >=6.0